### PR TITLE
Remove GIT_PROGRESS from CMakeLists.txt to allow compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ ExternalProject_Add(
   opengv_src
   GIT_REPOSITORY https://github.com/laurentkneip/opengv.git
   GIT_TAG master
-  GIT_PROGRESS 1
+#  GIT_PROGRESS 1
   UPDATE_COMMAND ""
   #PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/use_catkinized_eigen.patch
   CONFIGURE_COMMAND cd ../opengv_src && cmake . -DCMAKE_BUILD_TYPE=Release
@@ -31,3 +31,5 @@ install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/lib/
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 cs_export(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include
           LIBRARIES opengv)
+
+


### PR DESCRIPTION
Same issue: https://github.com/MIT-SPARK/Kimera-VIO-ROS/issues/19

As the issue above mentioned, we also weren't able to compile the wrappers dbow2 and opengv (Ubuntu 16.04, ROS Kinetic). We were able to "fix" the issue by commenting out the **GIT_PROGRESS** line. 

